### PR TITLE
green docstrings

### DIFF
--- a/themes/mariana-reference.json
+++ b/themes/mariana-reference.json
@@ -206,11 +206,19 @@
 			"scope": [
 				"comment",
 				"punctuation.definition.comment",
+			],
+			"settings": {
+				"foreground": "LIGHT_0"
+			}
+		},
+		{
+			"name": "Docstring",
+			"scope": [
 				"string.quoted.docstring",
 				"string.quoted.docstring punctuation.definition"
 			],
 			"settings": {
-				"foreground": "LIGHT_0"
+				"foreground": "MINT"
 			}
 		},
 		{


### PR DESCRIPTION
This simply matches (I think) the sublime style of differentiating docstrings from comments by rendering them as green/mint.

Feel free to reject if not to your taste, thanks for the project so far!