### PR TITLE
Python Syntax Highlight Improvements

### DIFF
--- a/themes/mariana-reference.json
+++ b/themes/mariana-reference.json
@@ -239,18 +239,6 @@
 			}
 		},
 		{
-			"name": "Python Punctuation",
-			"scope": [
-				"source.python punctuation.definition.arguments",
-				"source.python punctuation.definition.parameters",
-				"source.python punctuation.definition.list",
-				"source.python punctuation.definition.dict"
-			],
-			"settings": {
-				"foreground": "LIGHT_1"
-			}
-		},
-		{
 			"name": "Number",
 			"scope": "constant.numeric",
 			"settings": {
@@ -263,24 +251,6 @@
 			"settings": {
 				"foreground": "RED",
 				"fontStyle": "italic"
-			}
-		},
-		{
-			"name": "Python User-defined constant character placeholder",
-			"scope": [
-				"meta.fstring.python constant.character.format.placeholder"
-			],
-			"settings": {
-				"foreground": "LIGHT_1"
-			}
-		},
-		{
-			"name": "Python User-defined constant character placeholder",
-			"scope": [
-				"source.python meta.format constant.character.format.placeholder"
-			],
-			"settings": {
-				"foreground": "TEAL"
 			}
 		},
 		{
@@ -537,13 +507,6 @@
 			}
 		},
 		{
-			"name": "Storage modifier Python",
-			"scope": "source.python storage.modifier",
-			"settings": {
-				"foreground": "RED"
-			}
-		},
-		{
 			"name": "YAML Key",
 			"scope": "entity.name.tag.yaml",
 			"settings": {
@@ -789,6 +752,52 @@
 			"settings": {
 				"foreground": "ORANGE",
 				"fontStyle": "bold"
+			}
+		},
+		{
+			"name": "Python User-defined constant character placeholder",
+			"scope": [
+				"meta.fstring.python constant.character.format.placeholder"
+			],
+			"settings": {
+				"foreground": "LIGHT_1"
+			}
+		},
+		{
+			"name": "Python User-defined constant character placeholder",
+			"scope": [
+				"source.python meta.format constant.character.format.placeholder"
+			],
+			"settings": {
+				"foreground": "TEAL"
+			}
+		},
+		{
+			"name": "Python User-defined constant",
+			"scope": [
+				"source.python constant.other.caps.python"
+			],
+			"settings": {
+				"foreground": "LIGHT_1"
+			}
+		},
+		{
+			"name": "Python Punctuation",
+			"scope": [
+				"source.python punctuation.definition.arguments",
+				"source.python punctuation.definition.parameters",
+				"source.python punctuation.definition.list",
+				"source.python punctuation.definition.dict"
+			],
+			"settings": {
+				"foreground": "LIGHT_1"
+			}
+		},
+		{
+			"name": "Storage modifier Python",
+			"scope": "source.python storage.modifier",
+			"settings": {
+				"foreground": "RED"
 			}
 		},
 		{

--- a/themes/mariana-reference.json
+++ b/themes/mariana-reference.json
@@ -230,11 +230,24 @@
 			"name": "Punctuation",
 			"scope": [
 				"punctuation.definition",
-				"-punctuation.definition.numeric.base"
+				"-punctuation.definition.numeric.base",	
+				"punctuation.section.embedded"
 			],
 			"settings": {
 				"foreground": "TEAL"
 			}
+		},
+		{	
+			"name": "Python Punctuation",	
+			"scope": [	
+				"source.python punctuation.definition.arguments",	
+				"source.python punctuation.definition.parameters",	
+				"source.python punctuation.definition.list",	
+				"source.python punctuation.definition.dict"	
+			],	
+			"settings": {	
+				"foreground": "LIGHT_1"	
+			}	
 		},
 		{
 			"name": "Number",
@@ -252,14 +265,38 @@
 			}
 		},
 		{
-			"name": "User-defined constant",
-			"scope": [
-				"constant.character",
-				"constant.other"
-			],
-			"settings": {
-				"foreground": "PURPLE"
-			}
+			"name": "Function type",	
+			"scope": "support.type",	
+			"settings": {	
+				"fontStyle": "italic"	
+			}	
+		},	
+		{	
+			"name": "Python User-defined constant character placeholder",	
+			"scope": [	
+				"meta.fstring.python constant.character.format.placeholder"	
+			],	
+			"settings": {	
+				"foreground": "LIGHT_1"	
+			}	
+		},	
+		{	
+			"name": "Python User-defined constant character placeholder",	
+			"scope": [	
+				"source.python meta.format constant.character.format.placeholder"	
+			],	
+			"settings": {	
+				"foreground": "TEAL"	
+			}	
+		},	
+		{	
+			"name": "User-defined constant character",	
+			"scope": [	
+				"constant.character"	
+			],	
+			"settings": {	
+				"foreground": "PURPLE"	
+			}	
 		},
 		{
 			"name": "Member Variable",
@@ -352,6 +389,32 @@
 			}
 		},
 		{
+			"name": "Decorator name",	
+			"scope": "entity.name.function.decorator",	
+			"settings": {	
+				"foreground": "BLUE"	
+			}	
+		},	
+		{	
+			"name": "Decorator puntuation",	
+			"scope": "punctuation.definition.decorator",	
+			"settings": {	
+				"foreground": "TEAL"	
+			}	
+		},	
+		{	
+			"name": "Entity name type module",	
+			"scope": [	
+				"entity.name.type.module",	
+				"entity.name.type",	
+				"punctuation.definition.typeparameters"	
+			],	
+			"settings": {	
+				"foreground": "BLUE",	
+				"fontStyle": "italic"	
+			}	
+		},	
+		{
 			"name": "Entity name",
 			"scope": [
 				"entity.name",
@@ -363,6 +426,25 @@
 				"foreground": "ORANGE"
 			}
 		},
+		{
+			"name": "Entity name type Class",	
+			"scope": [	
+				"entity.name.type.class"	
+			],	
+			"settings": {	
+				"foreground": "ORANGE",	
+				"fontStyle": ""	
+			}	
+		},	
+		{	
+			"name": "Entity name",	
+			"scope": [	
+				"meta.function-call entity.name.function"	
+			],	
+			"settings": {	
+				"foreground": "BLUE"	
+			}	
+		},	
 		{
 			"name": "Inherited class",
 			"scope": "entity.other.inherited-class",
@@ -454,6 +536,37 @@
 				"foreground": "ORANGE"
 			}
 		},
+		{
+			"name": "Constant object",	
+			"scope": [	
+				"variable.other.constant.object"	
+			],	
+			"settings": {	
+				"foreground": "BLUE",	
+				"fontStyle": "italic"	
+			}	
+		},	
+		{	
+			"name": "Component",	
+			"scope": "support.class.component",	
+			"settings": {	
+				"foreground": "RED"	
+			}	
+		},	
+		{	
+			"name": "Storage modifier",	
+			"scope": "storage.modifier",	
+			"settings": {	
+				"foreground": "PURPLE"	
+			}	
+		},	
+		{	
+			"name": "Storage modifier Python",	
+			"scope": "source.python storage.modifier",	
+			"settings": {	
+				"foreground": "RED"	
+			}	
+		},	
 		{
 			"name": "YAML Key",
 			"scope": "entity.name.tag.yaml",

--- a/themes/mariana-reference.json
+++ b/themes/mariana-reference.json
@@ -236,17 +236,17 @@
 				"foreground": "TEAL"
 			}
 		},
-		{	
-			"name": "Python Punctuation",	
-			"scope": [	
-				"source.python punctuation.definition.arguments",	
-				"source.python punctuation.definition.parameters",	
-				"source.python punctuation.definition.list",	
-				"source.python punctuation.definition.dict"	
-			],	
-			"settings": {	
-				"foreground": "LIGHT_1"	
-			}	
+		{
+			"name": "Python Punctuation",
+			"scope": [
+				"source.python punctuation.definition.arguments",
+				"source.python punctuation.definition.parameters",
+				"source.python punctuation.definition.list",
+				"source.python punctuation.definition.dict"
+			],
+			"settings": {
+				"foreground": "LIGHT_1"
+			}
 		},
 		{
 			"name": "Number",
@@ -263,33 +263,33 @@
 				"fontStyle": "italic"
 			}
 		},
-		{	
-			"name": "Python User-defined constant character placeholder",	
-			"scope": [	
-				"meta.fstring.python constant.character.format.placeholder"	
-			],	
-			"settings": {	
-				"foreground": "LIGHT_1"	
-			}	
-		},	
-		{	
-			"name": "Python User-defined constant character placeholder",	
-			"scope": [	
-				"source.python meta.format constant.character.format.placeholder"	
-			],	
-			"settings": {	
-				"foreground": "TEAL"	
-			}	
-		},	
-		{	
-			"name": "User-defined constant",	
-			"scope": [	
+		{
+			"name": "Python User-defined constant character placeholder",
+			"scope": [
+				"meta.fstring.python constant.character.format.placeholder"
+			],
+			"settings": {
+				"foreground": "LIGHT_1"
+			}
+		},
+		{
+			"name": "Python User-defined constant character placeholder",
+			"scope": [
+				"source.python meta.format constant.character.format.placeholder"
+			],
+			"settings": {
+				"foreground": "TEAL"
+			}
+		},
+		{
+			"name": "User-defined constant",
+			"scope": [
 				"constant.character",
 				"constant.other"
-			],	
-			"settings": {	
-				"foreground": "PURPLE"	
-			}	
+			],
+			"settings": {
+				"foreground": "PURPLE"
+			}
 		},
 		{
 			"name": "Member Variable",
@@ -485,12 +485,12 @@
 			}
 		},
 		{
-			"name": "Storage modifier Python",	
-			"scope": "source.python storage.modifier",	
-			"settings": {	
-				"foreground": "RED"	
-			}	
-		},	
+			"name": "Storage modifier Python",
+			"scope": "source.python storage.modifier",
+			"settings": {
+				"foreground": "RED"
+			}
+		},
 		{
 			"name": "YAML Key",
 			"scope": "entity.name.tag.yaml",

--- a/themes/mariana-reference.json
+++ b/themes/mariana-reference.json
@@ -230,8 +230,7 @@
 			"name": "Punctuation",
 			"scope": [
 				"punctuation.definition",
-				"-punctuation.definition.numeric.base",	
-				"punctuation.section.embedded"
+				"-punctuation.definition.numeric.base"
 			],
 			"settings": {
 				"foreground": "TEAL"
@@ -264,13 +263,6 @@
 				"fontStyle": "italic"
 			}
 		},
-		{
-			"name": "Function type",	
-			"scope": "support.type",	
-			"settings": {	
-				"fontStyle": "italic"	
-			}	
-		},	
 		{	
 			"name": "Python User-defined constant character placeholder",	
 			"scope": [	
@@ -290,9 +282,10 @@
 			}	
 		},	
 		{	
-			"name": "User-defined constant character",	
+			"name": "User-defined constant",	
 			"scope": [	
-				"constant.character"	
+				"constant.character",
+				"constant.other"
 			],	
 			"settings": {	
 				"foreground": "PURPLE"	
@@ -389,32 +382,6 @@
 			}
 		},
 		{
-			"name": "Decorator name",	
-			"scope": "entity.name.function.decorator",	
-			"settings": {	
-				"foreground": "BLUE"	
-			}	
-		},	
-		{	
-			"name": "Decorator puntuation",	
-			"scope": "punctuation.definition.decorator",	
-			"settings": {	
-				"foreground": "TEAL"	
-			}	
-		},	
-		{	
-			"name": "Entity name type module",	
-			"scope": [	
-				"entity.name.type.module",	
-				"entity.name.type",	
-				"punctuation.definition.typeparameters"	
-			],	
-			"settings": {	
-				"foreground": "BLUE",	
-				"fontStyle": "italic"	
-			}	
-		},	
-		{
 			"name": "Entity name",
 			"scope": [
 				"entity.name",
@@ -426,25 +393,6 @@
 				"foreground": "ORANGE"
 			}
 		},
-		{
-			"name": "Entity name type Class",	
-			"scope": [	
-				"entity.name.type.class"	
-			],	
-			"settings": {	
-				"foreground": "ORANGE",	
-				"fontStyle": ""	
-			}	
-		},	
-		{	
-			"name": "Entity name",	
-			"scope": [	
-				"meta.function-call entity.name.function"	
-			],	
-			"settings": {	
-				"foreground": "BLUE"	
-			}	
-		},	
 		{
 			"name": "Inherited class",
 			"scope": "entity.other.inherited-class",
@@ -537,30 +485,6 @@
 			}
 		},
 		{
-			"name": "Constant object",	
-			"scope": [	
-				"variable.other.constant.object"	
-			],	
-			"settings": {	
-				"foreground": "BLUE",	
-				"fontStyle": "italic"	
-			}	
-		},	
-		{	
-			"name": "Component",	
-			"scope": "support.class.component",	
-			"settings": {	
-				"foreground": "RED"	
-			}	
-		},	
-		{	
-			"name": "Storage modifier",	
-			"scope": "storage.modifier",	
-			"settings": {	
-				"foreground": "PURPLE"	
-			}	
-		},	
-		{	
 			"name": "Storage modifier Python",	
 			"scope": "source.python storage.modifier",	
 			"settings": {	


### PR DESCRIPTION
In combination with https://github.com/mightbesimon/vscode-mariana/pull/8 it improves as shown in the images below:

left: Sublime, right: current implementation of vscode-mariana theme
![](https://user-images.githubusercontent.com/9253728/211535104-7e4386dc-0c2a-401d-a0d2-d0b759529317.png)

left: Sublime, right: PR implementation of vscode-mariana theme
![](https://user-images.githubusercontent.com/9253728/211535106-a7ba2ec8-e90e-4efc-9035-2fc081d5994b.png)
