### PR TITLE
Typescript Syntax Highlight Improvements

### DIFF
--- a/themes/mariana-reference.json
+++ b/themes/mariana-reference.json
@@ -237,6 +237,19 @@
 			}
 		},
 		{
+			"name": "TypeScript Punctuation",	
+			"scope": [	
+				"source.ts punctuation.definition.parameters",	
+				"source.ts punctuation.definition.block",	
+				"source.tsx punctuation.definition.parameters",	
+				"source.tsx punctuation.definition.block",	
+				"source.tsx punctuation.definition.binding-pattern"	
+			],	
+			"settings": {	
+				"foreground": "LIGHT_1"	
+			}	
+		},
+		{
 			"name": "Number",
 			"scope": "constant.numeric",
 			"settings": {
@@ -653,6 +666,51 @@
 			"settings": {
 				"foreground": "LIGHT_1"
 			}
+		},
+		{	
+			"name": "TypeScript annotation",	
+			"scope": "keyword.operator.type.annotation.tsx",	
+			"settings": {	
+				"foreground": "LIGHT_0"	
+			}	
+		},	
+		{	
+			"name": "TypeScript keyword control",	
+			"scope": "source.ts meta.function meta.block keyword.control.as",	
+			"settings": {	
+				"foreground": "CORAL"	
+			}	
+		},	
+		{	
+			"name": "TypeScript constant",	
+			"scope": [	
+				"variable.other.constant entity.name.function.tsx",	
+				"meta.definition.property entity.name.function.tsx"	
+			],	
+			"settings": {	
+				"foreground": "LIGHT_1"	
+			}	
+		},	
+		{	
+			"name": "TypeScript variable",	
+			"scope": "variable.other.readwrite.tsx",	
+			"settings": {	
+				"foreground": "LIGHT_1"	
+			}	
+		},	
+		{	
+			"name": "TypeScript parameter",	
+			"scope": "meta.object.member.tsx variable.other.readwrite.tsx",	
+			"settings": {	
+				"foreground": "ORANGE"	
+			}	
+		},	
+		{	
+			"name": "TypeScript modifier",	
+			"scope": "source.tsx storage.modifier",	
+			"settings": {	
+				"fontStyle": "italic"	
+			}	
 		},
 		{
 			"scope": "constant.numeric.line-number.match",

--- a/themes/mariana-reference.json
+++ b/themes/mariana-reference.json
@@ -237,19 +237,6 @@
 			}
 		},
 		{
-			"name": "TypeScript Punctuation",
-			"scope": [
-				"source.ts punctuation.definition.parameters",
-				"source.ts punctuation.definition.block",
-				"source.tsx punctuation.definition.parameters",
-				"source.tsx punctuation.definition.block",
-				"source.tsx punctuation.definition.binding-pattern"
-			],
-			"settings": {
-				"foreground": "LIGHT_1"
-			}
-		},
-		{
 			"name": "Number",
 			"scope": "constant.numeric",
 			"settings": {
@@ -663,6 +650,19 @@
 		{
 			"name": "CSS Properties",
 			"scope": "support.type.property-name",
+			"settings": {
+				"foreground": "LIGHT_1"
+			}
+		},
+		{
+			"name": "TypeScript Punctuation",
+			"scope": [
+				"source.ts punctuation.definition.parameters",
+				"source.ts punctuation.definition.block",
+				"source.tsx punctuation.definition.parameters",
+				"source.tsx punctuation.definition.block",
+				"source.tsx punctuation.definition.binding-pattern"
+			],
 			"settings": {
 				"foreground": "LIGHT_1"
 			}

--- a/themes/mariana-reference.json
+++ b/themes/mariana-reference.json
@@ -237,17 +237,17 @@
 			}
 		},
 		{
-			"name": "TypeScript Punctuation",	
-			"scope": [	
-				"source.ts punctuation.definition.parameters",	
-				"source.ts punctuation.definition.block",	
-				"source.tsx punctuation.definition.parameters",	
-				"source.tsx punctuation.definition.block",	
-				"source.tsx punctuation.definition.binding-pattern"	
-			],	
-			"settings": {	
-				"foreground": "LIGHT_1"	
-			}	
+			"name": "TypeScript Punctuation",
+			"scope": [
+				"source.ts punctuation.definition.parameters",
+				"source.ts punctuation.definition.block",
+				"source.tsx punctuation.definition.parameters",
+				"source.tsx punctuation.definition.block",
+				"source.tsx punctuation.definition.binding-pattern"
+			],
+			"settings": {
+				"foreground": "LIGHT_1"
+			}
 		},
 		{
 			"name": "Number",
@@ -667,50 +667,50 @@
 				"foreground": "LIGHT_1"
 			}
 		},
-		{	
-			"name": "TypeScript annotation",	
-			"scope": "keyword.operator.type.annotation.tsx",	
-			"settings": {	
-				"foreground": "LIGHT_0"	
-			}	
-		},	
-		{	
-			"name": "TypeScript keyword control",	
-			"scope": "source.ts meta.function meta.block keyword.control.as",	
-			"settings": {	
-				"foreground": "CORAL"	
-			}	
-		},	
-		{	
-			"name": "TypeScript constant",	
-			"scope": [	
-				"variable.other.constant entity.name.function.tsx",	
-				"meta.definition.property entity.name.function.tsx"	
-			],	
-			"settings": {	
-				"foreground": "LIGHT_1"	
-			}	
-		},	
-		{	
-			"name": "TypeScript variable",	
-			"scope": "variable.other.readwrite.tsx",	
-			"settings": {	
-				"foreground": "LIGHT_1"	
-			}	
-		},	
-		{	
-			"name": "TypeScript parameter",	
-			"scope": "meta.object.member.tsx variable.other.readwrite.tsx",	
-			"settings": {	
-				"foreground": "ORANGE"	
-			}	
-		},	
-		{	
-			"name": "TypeScript modifier",	
-			"scope": "source.tsx storage.modifier",	
-			"settings": {	
-				"fontStyle": "italic"	
-			}	
+		{
+			"name": "TypeScript annotation",
+			"scope": "keyword.operator.type.annotation.tsx",
+			"settings": {
+				"foreground": "LIGHT_0"
+			}
+		},
+		{
+			"name": "TypeScript keyword control",
+			"scope": "source.ts meta.function meta.block keyword.control.as",
+			"settings": {
+				"foreground": "CORAL"
+			}
+		},
+		{
+			"name": "TypeScript constant",
+			"scope": [
+				"variable.other.constant entity.name.function.tsx",
+				"meta.definition.property entity.name.function.tsx"
+			],
+			"settings": {
+				"foreground": "LIGHT_1"
+			}
+		},
+		{
+			"name": "TypeScript variable",
+			"scope": "variable.other.readwrite.tsx",
+			"settings": {
+				"foreground": "LIGHT_1"
+			}
+		},
+		{
+			"name": "TypeScript parameter",
+			"scope": "meta.object.member.tsx variable.other.readwrite.tsx",
+			"settings": {
+				"foreground": "ORANGE"
+			}
+		},
+		{
+			"name": "TypeScript modifier",
+			"scope": "source.tsx storage.modifier",
+			"settings": {
+				"fontStyle": "italic"
+			}
 		},
 		{
 			"scope": "constant.numeric.line-number.match",


### PR DESCRIPTION
In combination with https://github.com/mightbesimon/vscode-mariana/pull/8 it improves as shown in the images below:

left: Sublime, right: current implementation of vscode-mariana theme
![](https://user-images.githubusercontent.com/9253728/211535111-44c4d6c8-6af6-4608-82a4-db2e7b4301a1.png)

left: Sublime, right: PR implementation of vscode-mariana theme
![](https://user-images.githubusercontent.com/9253728/211535114-cf56d2ed-68a7-49c0-8b04-fc6d1a3ec16d.png)



left: Sublime, right: current implementation of vscode-mariana theme
![](https://user-images.githubusercontent.com/9253728/211535117-01c0c914-4540-4d32-afac-62eb8731e1ec.png)

left: Sublime, right: PR implementation of vscode-mariana theme
![](https://user-images.githubusercontent.com/9253728/211535120-6ddc01c7-47db-4d33-b187-37307a4f6519.png)



left: Sublime, right: current implementation of vscode-mariana theme
![](https://user-images.githubusercontent.com/9253728/211535142-abf91714-71e8-4ec3-a578-37a961ec197b.png)

left: Sublime, right: PR implementation of vscode-mariana theme
![](https://user-images.githubusercontent.com/9253728/211535144-3ddfe523-bb8e-4fcc-9ac6-dac01d1b22b0.png)

