### PR TITLE
Graphql Syntax Highlight Improvements

### DIFF
--- a/themes/mariana-reference.json
+++ b/themes/mariana-reference.json
@@ -655,57 +655,57 @@
 			}
 		},
 		{
-			"name": "Graphql type",	
-			"scope": "support.type.graphql",	
-			"settings": {	
-				"foreground": "ORANGE",	
-				"fontStyle": ""	
-			}	
-		},	
-		{	
-			"name": "Graphql referenced type",	
-			"scope": [	
-				"meta.type.list.graphql support.type.graphql",	
-				"meta.type.object.graphql support.type.graphql"	
-			],	
-			"settings": {	
-				"foreground": "LIGHT_1"	
-			}	
-		},	
-		{	
-			"name": "Graphql variable",	
-			"scope": [	
-				"variable.graphql",	
-				"constant.character.enum.graphql"	
-			],	
-			"settings": {	
-				"foreground": "ORANGE"	
-			}	
-		},	
-		{	
-			"name": "Graphql string",	
-			"scope": [	
-				"meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql support.type.graphql",	
-				"meta.type.object.graphql meta.variables.graphql",	
-				"graphql.description.SINGLELINE"	
-			],	
-			"settings": {	
-				"foreground": "MINT"	
-			}	
-		},	
-		{	
-			"name": "Graphql entity",	
-			"scope": "entity.name.function.directive.graphql",	
-			"settings": {	
-				"foreground": "BLUE"	
-			}	
-		},	
-		{	
-			"name": "Graphql braces",	
-			"scope": "meta.brace.square.graphql",	
-			"settings": {	
-				"foreground": "RED"	
-			}	
+			"name": "Graphql type",
+			"scope": "support.type.graphql",
+			"settings": {
+				"foreground": "ORANGE",
+				"fontStyle": ""
+			}
+		},
+		{
+			"name": "Graphql referenced type",
+			"scope": [
+				"meta.type.list.graphql support.type.graphql",
+				"meta.type.object.graphql support.type.graphql"
+			],
+			"settings": {
+				"foreground": "LIGHT_1"
+			}
+		},
+		{
+			"name": "Graphql variable",
+			"scope": [
+				"variable.graphql",
+				"constant.character.enum.graphql"
+			],
+			"settings": {
+				"foreground": "ORANGE"
+			}
+		},
+		{
+			"name": "Graphql string",
+			"scope": [
+				"meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql support.type.graphql",
+				"meta.type.object.graphql meta.variables.graphql",
+				"graphql.description.SINGLELINE"
+			],
+			"settings": {
+				"foreground": "MINT"
+			}
+		},
+		{
+			"name": "Graphql entity",
+			"scope": "entity.name.function.directive.graphql",
+			"settings": {
+				"foreground": "BLUE"
+			}
+		},
+		{
+			"name": "Graphql braces",
+			"scope": "meta.brace.square.graphql",
+			"settings": {
+				"foreground": "RED"
+			}
 		},
 		{
 			"scope": "constant.numeric.line-number.match",

--- a/themes/mariana-reference.json
+++ b/themes/mariana-reference.json
@@ -655,6 +655,59 @@
 			}
 		},
 		{
+			"name": "Graphql type",	
+			"scope": "support.type.graphql",	
+			"settings": {	
+				"foreground": "ORANGE",	
+				"fontStyle": ""	
+			}	
+		},	
+		{	
+			"name": "Graphql referenced type",	
+			"scope": [	
+				"meta.type.list.graphql support.type.graphql",	
+				"meta.type.object.graphql support.type.graphql"	
+			],	
+			"settings": {	
+				"foreground": "LIGHT_1"	
+			}	
+		},	
+		{	
+			"name": "Graphql variable",	
+			"scope": [	
+				"variable.graphql",	
+				"constant.character.enum.graphql"	
+			],	
+			"settings": {	
+				"foreground": "ORANGE"	
+			}	
+		},	
+		{	
+			"name": "Graphql string",	
+			"scope": [	
+				"meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql support.type.graphql",	
+				"meta.type.object.graphql meta.variables.graphql",	
+				"graphql.description.SINGLELINE"	
+			],	
+			"settings": {	
+				"foreground": "MINT"	
+			}	
+		},	
+		{	
+			"name": "Graphql entity",	
+			"scope": "entity.name.function.directive.graphql",	
+			"settings": {	
+				"foreground": "BLUE"	
+			}	
+		},	
+		{	
+			"name": "Graphql braces",	
+			"scope": "meta.brace.square.graphql",	
+			"settings": {	
+				"foreground": "RED"	
+			}	
+		},
+		{
 			"scope": "constant.numeric.line-number.match",
 			"settings": {
 				"foreground": "RED"


### PR DESCRIPTION
In combination with https://github.com/mightbesimon/vscode-mariana/pull/8 it improves as shown in the images below:

left: Sublime, right: current implementation of vscode-mariana theme
![](https://user-images.githubusercontent.com/9253728/211535131-85417d54-732b-4061-927a-d75c5b9f4bc7.png)


left: Sublime, right: PR implementation of vscode-mariana theme
![](https://user-images.githubusercontent.com/9253728/211535135-1b50ebb8-d4d9-4805-87d7-a6f2bf81bec0.png)
