### PR TITLE
Json Syntax Highlight Improvements

### DIFF
--- a/themes/mariana-reference.json
+++ b/themes/mariana-reference.json
@@ -663,6 +663,18 @@
 			}
 		},
 		{
+			"name": "JSON punctuation",
+			"scope": [
+				"punctuation.definition.array.begin.json",
+				"punctuation.definition.array.end.json",
+				"punctuation.definition.dictionary.begin.json",
+				"punctuation.definition.dictionary.end.json"
+			],
+			"settings": {
+				"foreground": "LIGHT_1"
+			}
+		},
+		{
 			"scope": "constant.numeric.line-number.match",
 			"settings": {
 				"foreground": "RED"

--- a/themes/mariana-reference.json
+++ b/themes/mariana-reference.json
@@ -655,6 +655,14 @@
 			}
 		},
 		{
+			"name": "JSON Properties",	
+			"scope": "support.type.property-name.json",	
+			"settings": {	
+				"foreground": "MINT",	
+				"fontStyle": ""	
+			}	
+		},
+		{
 			"scope": "constant.numeric.line-number.match",
 			"settings": {
 				"foreground": "RED"

--- a/themes/mariana-reference.json
+++ b/themes/mariana-reference.json
@@ -655,12 +655,12 @@
 			}
 		},
 		{
-			"name": "JSON Properties",	
-			"scope": "support.type.property-name.json",	
-			"settings": {	
-				"foreground": "MINT",	
-				"fontStyle": ""	
-			}	
+			"name": "JSON Properties",
+			"scope": "support.type.property-name.json",
+			"settings": {
+				"foreground": "MINT",
+				"fontStyle": ""
+			}
 		},
 		{
 			"scope": "constant.numeric.line-number.match",

--- a/themes/mariana-reference.json
+++ b/themes/mariana-reference.json
@@ -655,26 +655,6 @@
 			}
 		},
 		{
-			"name": "JSON Properties",
-			"scope": "support.type.property-name.json",
-			"settings": {
-				"foreground": "MINT",
-				"fontStyle": ""
-			}
-		},
-		{
-			"name": "JSON punctuation",
-			"scope": [
-				"punctuation.definition.array.begin.json",
-				"punctuation.definition.array.end.json",
-				"punctuation.definition.dictionary.begin.json",
-				"punctuation.definition.dictionary.end.json"
-			],
-			"settings": {
-				"foreground": "LIGHT_1"
-			}
-		},
-		{
 			"scope": "constant.numeric.line-number.match",
 			"settings": {
 				"foreground": "RED"
@@ -720,6 +700,26 @@
 			"settings": {
 				"foreground": "ORANGE",
 				"fontStyle": "bold"
+			}
+		},
+		{
+			"name": "JSON Properties",
+			"scope": "support.type.property-name.json",
+			"settings": {
+				"foreground": "MINT",
+				"fontStyle": ""
+			}
+		},
+		{
+			"name": "JSON punctuation",
+			"scope": [
+				"punctuation.definition.array.begin.json",
+				"punctuation.definition.array.end.json",
+				"punctuation.definition.dictionary.begin.json",
+				"punctuation.definition.dictionary.end.json"
+			],
+			"settings": {
+				"foreground": "LIGHT_1"
 			}
 		}
 	]


### PR DESCRIPTION
In combination with https://github.com/mightbesimon/vscode-mariana/pull/8 it improves as shown in the images below:

left: Sublime, right: current implementation of vscode-mariana theme
![](https://user-images.githubusercontent.com/9253728/211535137-e364b6f8-1bfb-40cc-9c9d-83d22fe5d6af.png)


left: Sublime, right: PR implementation of vscode-mariana theme
![](https://user-images.githubusercontent.com/9253728/211535140-ea96a5f6-8db2-4a0f-9960-4c7a0386a384.png)
