### PR TITLE
Rainbow csv Syntax Highlight Improvements

### DIFF
--- a/themes/mariana-reference.json
+++ b/themes/mariana-reference.json
@@ -655,6 +655,23 @@
 			}
 		},
 		{
+			"name": "Rainbow csv 0",	
+			"scope": [	
+				"rainbowgroup markup.bold",	
+				"rainbowgroup entity.name.type"	
+			],	
+			"settings": {	
+				"fontStyle": ""	
+			}	
+		},	
+		{	
+			"name": "Rainbow csv 1",	
+			"scope": "rainbowgroup constant.numeric",	
+			"settings": {	
+				"foreground": "PURPLE"	
+			}	
+		},
+		{
 			"scope": "constant.numeric.line-number.match",
 			"settings": {
 				"foreground": "RED"

--- a/themes/mariana-reference.json
+++ b/themes/mariana-reference.json
@@ -655,21 +655,21 @@
 			}
 		},
 		{
-			"name": "Rainbow csv 0",	
-			"scope": [	
-				"rainbowgroup markup.bold",	
-				"rainbowgroup entity.name.type"	
-			],	
-			"settings": {	
-				"fontStyle": ""	
-			}	
-		},	
-		{	
-			"name": "Rainbow csv 1",	
-			"scope": "rainbowgroup constant.numeric",	
-			"settings": {	
-				"foreground": "PURPLE"	
-			}	
+			"name": "Rainbow csv 0",
+			"scope": [
+				"rainbowgroup markup.bold",
+				"rainbowgroup entity.name.type"
+			],
+			"settings": {
+				"fontStyle": ""
+			}
+		},
+		{
+			"name": "Rainbow csv 1",
+			"scope": "rainbowgroup constant.numeric",
+			"settings": {
+				"foreground": "PURPLE"
+			}
 		},
 		{
 			"scope": "constant.numeric.line-number.match",


### PR DESCRIPTION
It allows the plugin [rainbow csv](https://marketplace.visualstudio.com/items?itemName=mechatroner.rainbow-csv) to match the column colors of Sublime's [rainbow csv](https://packagecontrol.io/packages/rainbow_csv)