### PR TITLE
Response to PR #8

### DIFF
--- a/themes/mariana-reference.json
+++ b/themes/mariana-reference.json
@@ -254,13 +254,6 @@
 			}
 		},
 		{
-			"name": "Function type",
-			"scope": "support.type",
-			"settings": {
-				"fontStyle": "italic"
-			}
-		},
-		{
 			"name": "User-defined constant character",
 			"scope": [
 				"constant.character"
@@ -484,13 +477,18 @@
 			}
 		},
 		{
-			"name": "Library class/type",
-			"scope": [
-				"support.type",
-				"support.class"
-			],
+			"name": "Library class",
+			"scope": "support.class",
 			"settings": {
 				"foreground": "BLUE"
+			}
+		},
+		{
+			"name": "Library type",
+			"scope": "support.type",
+			"settings": {
+				"foreground": "BLUE",
+				"fontStyle": "italic"
 			}
 		},
 		{

--- a/themes/mariana-reference.json
+++ b/themes/mariana-reference.json
@@ -264,9 +264,17 @@
 			}
 		},
 		{
-			"name": "User-defined constant character",
+			"name": "Ellipsis constant",
+			"scope": "constant.other.ellipsis",
+			"settings": {
+				"foreground": "RED"
+			}
+		},
+		{
+			"name": "User-defined constant",
 			"scope": [
-				"constant.character"
+				"constant.character",
+				"constant.other"
 			],
 			"settings": {
 				"foreground": "PURPLE"
@@ -526,7 +534,7 @@
 			"name": "Storage modifier",
 			"scope": "storage.modifier",
 			"settings": {
-				"foreground": "PURPLE"
+				"foreground": "RED"
 			}
 		},
 		{

--- a/themes/mariana-reference.json
+++ b/themes/mariana-reference.json
@@ -254,6 +254,16 @@
 			}
 		},
 		{
+			"name": "Built-in constant object",
+			"scope": [
+				"variable.other.constant.object"
+			],
+			"settings": {
+				"foreground": "BLUE",
+				"fontStyle": "italic"
+			}
+		},
+		{
 			"name": "User-defined constant character",
 			"scope": [
 				"constant.character"
@@ -503,16 +513,6 @@
 			"scope": "invalid.deprecated",
 			"settings": {
 				"foreground": "ORANGE"
-			}
-		},
-		{
-			"name": "Constant object",
-			"scope": [
-				"variable.other.constant.object"
-			],
-			"settings": {
-				"foreground": "BLUE",
-				"fontStyle": "italic"
 			}
 		},
 		{

--- a/themes/mariana-reference.json
+++ b/themes/mariana-reference.json
@@ -377,18 +377,6 @@
 			}
 		},
 		{
-			"name": "Entity name type module",
-			"scope": [
-				"entity.name.type.module",
-				"entity.name.type",
-				"punctuation.definition.typeparameters"
-			],
-			"settings": {
-				"foreground": "BLUE",
-				"fontStyle": "italic"
-			}
-		},
-		{
 			"name": "Entity name",
 			"scope": [
 				"entity.name",
@@ -401,7 +389,19 @@
 			}
 		},
 		{
-			"name": "Entity name type Class",
+			"name": "Entity name type module",
+			"scope": [
+				"entity.name.type.module",
+				"entity.name.type",
+				"punctuation.definition.typeparameters"
+			],
+			"settings": {
+				"foreground": "BLUE",
+				"fontStyle": "italic"
+			}
+		},
+		{
+			"name": "Entity name type class",
 			"scope": [
 				"entity.name.type.class"
 			],
@@ -411,7 +411,7 @@
 			}
 		},
 		{
-			"name": "Entity name",
+			"name": "Entity name function",
 			"scope": [
 				"meta.function-call entity.name.function"
 			],


### PR DESCRIPTION
- rearranged / reordered some items to group similar items together
- added the ellipsis constant `...` for python
- set storage modifiers to red (sublime reference below)
- set user defined constants back to purple (I know this differs from sublime, I just liked the vscode feature that colours user defined constants differently to regular variables. I think its a useful feature)

<img width="686" alt="Screen Shot 2023-09-09 at 10 23 18 PM" src="https://github.com/mightbesimon/vscode-mariana/assets/60593422/4ed18107-ffbf-4865-8349-16ce88b240b7">